### PR TITLE
Test to copy directory with files with same name prefix

### DIFF
--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -285,10 +285,11 @@ def test_gcs_glob(gcs):
         for f in gcs.glob(TEST_BUCKET + "/nested/*")
         if gcs.isfile(f)
     )
+    # the following is no longer true since the glob method list the root path
     # Ensure the glob only fetches prefixed folders
-    gcs.dircache.clear()
-    gcs.glob(TEST_BUCKET + "/nested**1")
-    assert all(d.startswith(TEST_BUCKET + "/nested") for d in gcs.dircache)
+    # gcs.dircache.clear()
+    # gcs.glob(TEST_BUCKET + "/nested**1")
+    # assert all(d.startswith(TEST_BUCKET + "/nested") for d in gcs.dircache)
     # the following is no longer true as of #437
     # gcs.glob(TEST_BUCKET + "/test*")
     # assert TEST_BUCKET + "/test" in gcs.dircache


### PR DESCRIPTION
One test case in gcsfs had a weird behavior where copying a folder also copied the files that has the same name prefix as the folder name. For example:

```python

# Files
# -- subdir.txt
# -- subdir
# ---- subfile.txt

fs.cp("subdir", "target")

# Expected target folder content: ["subfile.txt"]

# Content with gcsfs: ["subdir.txt", "subdir/subfile.txt"]
```

This PR fixes this behavior. I guess there's a better way to fix this but I had to also remove the `_glob` method for it to work so the `_glob` method from the async fs is used.

@ianthomas23 @martindurant I created a PR here for now since I need the updates from [this other PR](https://github.com/fsspec/filesystem_spec/pull/1329) for it to work. I'll create a PR with `gcsfs` master branch as the target as soon as the other one is merged.